### PR TITLE
feat: overridable styles for AnnouncementsPage Component

### DIFF
--- a/.changeset/strong-clouds-report.md
+++ b/.changeset/strong-clouds-report.md
@@ -1,0 +1,5 @@
+---
+'@k-phoen/backstage-plugin-announcements': minor
+---
+
+Overridable styles for AnnouncementsPage Component

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -48,6 +48,11 @@ import { useDeleteAnnouncementDialogState } from './useDeleteAnnouncementDialogS
 import { Pagination } from '@material-ui/lab';
 import { ContextMenu } from './ContextMenu';
 
+export type AnnouncementsStylePickerClassKey =
+  | 'itemCardHeader'
+  | 'cardHeader'
+  | 'link';
+
 const useStyles = makeStyles(theme => ({
   cardHeader: {
     color: theme.palette.text.primary,
@@ -57,7 +62,17 @@ const useStyles = makeStyles(theme => ({
     justifyContent: 'center',
     marginTop: theme.spacing(4),
   },
-}));
+  ItemCardHeader: {
+
+  },
+  link: {
+
+  },
+  }),
+  {
+    name: 'AnnouncementsStylePicker',
+  },
+);
 
 const AnnouncementCard = ({
   announcement,
@@ -85,7 +100,7 @@ const AnnouncementCard = ({
     <>
       By{' '}
       <EntityPeekAheadPopover entityRef={announcement.publisher}>
-        <Link to={entityLink(publisherRef)}>{publisherRef.name}</Link>
+        <Link to={entityLink(publisherRef)} className={classes.link}>{publisherRef.name}</Link>
       </EntityPeekAheadPopover>
       {announcement.category && (
         <>
@@ -109,7 +124,7 @@ const AnnouncementCard = ({
   return (
     <Card>
       <CardMedia>
-        <ItemCardHeader title={title} subtitle={subTitle} />
+        <ItemCardHeader title={title} subtitle={subTitle} classes={{root : useStyles().itemCardHeader}}/>
       </CardMedia>
       <CardContent>{announcement.excerpt}</CardContent>
       <CardActions>

--- a/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -62,7 +62,7 @@ const useStyles = makeStyles(theme => ({
     justifyContent: 'center',
     marginTop: theme.spacing(4),
   },
-  ItemCardHeader: {
+  itemCardHeader: {
 
   },
   link: {

--- a/plugins/announcements/src/components/OverridableComponents.tsx
+++ b/plugins/announcements/src/components/OverridableComponents.tsx
@@ -1,0 +1,13 @@
+import { Overrides } from '@material-ui/core/styles/overrides';
+import { StyleRules } from '@material-ui/core/styles/withStyles';
+import { AnnouncementsStylePickerClassKey } from './AnnouncementsPage/AnnouncementsPage';
+
+export type AnnouncementsNameToClassKey = {
+    AnnouncementsStylePicker: AnnouncementsStylePickerClassKey;
+};
+
+export type BackstageOverrides = Overrides & {
+  [Name in keyof AnnouncementsNameToClassKey]?: Partial<
+    StyleRules<AnnouncementsNameToClassKey[Name]>
+  >;
+};

--- a/plugins/announcements/src/index.ts
+++ b/plugins/announcements/src/index.ts
@@ -1,1 +1,2 @@
 export * from './plugin';
+export * from './components/OverridableComponents';


### PR DESCRIPTION
https://github.com/K-Phoen/backstage-plugin-announcements/pull/154

---

The plugin does offer the ability to pass themeId, which allows us to customize the header of the AnnouncementsPage but unfortunately not the cards.

We would like to have some style customizations done in Card. So we made some of the UI components overridable in AnnouncementsPage by defining CSS properties (itemCardHeader, link), providing a name to the makeStyles function, making the styles overridable in the OverridableComponents.tsx file, and exporting the overrides from the plugin. The same pattern is used by the backstage catalog-react [plugin](https://github.com/backstage/backstage/blob/eeb97f65926cb83459bdba37cdb26d440b933aa7/plugins/catalog-react/src/overridableComponents.ts) to allow users to override component styles.

We can use it like this in the backstage app.

```
import { BackstageOverrides as AnnouncementsOverrides } from '@k-pheon/backstage-plugin-announcements';
import { BackstageOverrides } from '@backstage/core-components';

const createCustomThemeOverrides = (): BackstageOverrides & AnnouncementsOverrides => {
  return {
    AnnouncementsStylePicker: {
      itemCardHeader: {
        // custom styles
      },
      cardHeader: {
        // custom styles
      },
      link: {
        // custom styles
      },
    },
  };
};
```